### PR TITLE
changed Gemfile comment to reflect new name of project

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "http://rubygems.org"
 
-# Specify your gem's dependencies in gitscrub.gemspec
+# Specify your gem's dependencies in githug.gemspec
 gemspec


### PR DESCRIPTION
The Gemfile comment said to specific dependencies in gitscrub.gemspec. I changed it to the current name of the project.
