### PR TITLE
Fixed the hint for the rename commit level

### DIFF
--- a/levels/rename_commit.rb
+++ b/levels/rename_commit.rb
@@ -18,5 +18,5 @@ solution do
 end
 
 hint do
-  puts "Take a look the -i flag of the rebase command"
+  puts "Take a look at the --amend flag of the commit command"
 end


### PR DESCRIPTION
It looks like the hint was originally copied from the squash level
