### PR TITLE
Clarify challenge and hint text of the stage_lines level

### DIFF
--- a/levels/stage_lines.rb
+++ b/levels/stage_lines.rb
@@ -1,6 +1,6 @@
 difficulty 3
 
-description "You've made changes within a single file that belong to two different features, but niether of the changes are yet staged. Stage and commit only the changes belonging to the first feature."
+description "You've made changes within a single file that belong to two different features, but niether of the changes are yet staged. Stage only the changes belonging to the first feature."
 
 setup do
   repo.init
@@ -25,5 +25,5 @@ solution do
 end
 
 hint do
-  puts "Read about the -p flag which can be passed to the 'add' command; man git-add. After that have a look the options available while using 'add -p' mode to manupulate hunks."
+  puts "You might want to try to manipulate the hunks of the diff to choose which lines of the diff get staged. Read about the flags which can be passed to the 'add' command; man git-add."
 end


### PR DESCRIPTION
Firstly, the challenge text instructs the player to commit the changes of the first feature, however the solution depends on the changes of the first feature being present in the index.

The previous hint text was leading. there are several ways to complete this challenge so this text change just nudges the player to read more about the options available in the 'add' command.
