### PR TITLE
Fixed issue #49: Log level (#12) does not work

### DIFF
--- a/levels/log.rb
+++ b/levels/log.rb
@@ -10,7 +10,7 @@ setup do
 end
 
 solution do
-  repo.commits.last.id_abbrev == request("What are the first 7 characters of the hash of the most recent commit?") 
+  repo.commits.first.id_abbrev == request("What are the first 7 characters of the hash of the most recent commit?") 
 end
 
 hint do


### PR DESCRIPTION
The response was compared against the short SHA of the oldest commit, instead of the most recent one.
