### PR TITLE
Fix stage_lines level to work even when color.diff=always is set in git config

### DIFF
--- a/levels/stage_lines.rb
+++ b/levels/stage_lines.rb
@@ -21,7 +21,7 @@ setup do
 end
 
 solution do
-  `git diff --staged` =~ /\+This change belongs to the first feature/ && `git diff` =~ /\+This change belongs to the second feature/
+  `git diff --no-color --staged` =~ /\+This change belongs to the first feature/ && `git diff --no-color` =~ /\+This change belongs to the second feature/
 end
 
 hint do


### PR DESCRIPTION
I have "color.diff=always" in my git config so my correct solution to stage_lines was not recognized. Using the --no-color option to git diff ensures that the correct solution is recognized.
