### PR TITLE
Change hash systax to support ruby 1.8

### DIFF
--- a/levels/merge_squash.rb
+++ b/levels/merge_squash.rb
@@ -8,7 +8,7 @@ setup do
   repo.add        "file1"
   repo.commit_all "First commit"
 
-  repo.git.native :checkout, {b: true}, 'long-feature-branch'
+  repo.git.native :checkout, {"b" => true}, 'long-feature-branch'
   File.open("file3", 'w') { |f| f << "some feature\n" }
   repo.add        "file3"
   repo.commit_all "Developing new features"


### PR DESCRIPTION
The merge_squash level fails on ruby 1.8 because of the new hash notation.
