### PR TITLE
Override core.excludesfile and add a sample .swp file for gitignore level

### DIFF
--- a/levels/ignore.rb
+++ b/levels/ignore.rb
@@ -3,6 +3,10 @@ description "The text editor 'vim' creates files ending in .swp (swap files) for
 
 setup do
   repo.init
+  FileUtils.touch("README.swp")
+  file = File.open(".git/config", "w") do |file|
+    file.puts "[core]\nexcludesfile="
+  end
 end
 
 solution do


### PR DESCRIPTION
The ignore.rb lesson was a little confusing for me since I already have *.swp in my global excludesfiles (~/.gitignore).

To make the effect of the .gitconfig change more obvious to players, I suggest adding a .swp file and ensuring core.excludesfile is NOT set.
