### PR TITLE
Removed a contradiction in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,12 @@ setup do
 end
 
 solution do
-  return false unless repo.status.files.keys.include?("README")
-  return false if repo.status.files["README"].untracked
-  true
+  solved = true
+
+  solved = false unless repo.status.files.keys.include?("README")
+  solved = false if repo.status.files["README"].untracked
+
+  solved
 end
 
 hint do


### PR DESCRIPTION
I noticed in the README under `An example level` this example:

```
solution do
  return false unless repo.status.files.keys.include?("README")
  return false if repo.status.files["README"].untracked
  true
end
```

contradicted the note a few lines down:

> **note** Because solution is a Proc, you cannot prematurely return out of it and as a result, must put an explicit return on the last line of the solution block.

So this PR fixes that :+1: 
