### PR TITLE
rename_commit.rb: clarify meaning of 'first' commit

### DIFF
--- a/levels/rename_commit.rb
+++ b/levels/rename_commit.rb
@@ -1,5 +1,5 @@
 difficulty 3
-description "Correct the typo in the message of your first commit."
+description "Correct the typo in the message of your first (non-root) commit."
 
 setup do
   repo.init


### PR DESCRIPTION
The wording of the challenge suggests that one needs to amend the commit
that one would get from the following command:

``` console
$ git rev-list HEAD | tail -1
```

i.e. the first commit which was made. The "first" commit this level
talks about is, to my mind, the second commit.

After a degree of Googling, I found the magic incantation to amend the
root commit. This is non-trivial with `git rebase`. Admittedly I
should've checked which commit actually _had_ the typo but this problem
would've been avoided all together had the challenge been clearer.
