### PR TITLE
Clarified 'remove the file system' in rm_cached level

### DIFF
--- a/levels/rm_cached.rb
+++ b/levels/rm_cached.rb
@@ -1,6 +1,6 @@
 difficulty 2
 
-description "A file (deleteme.rb) has accidentally been added to your staging area, find out which file and remove it from the staging area.  *NOTE* Do not remove the file system, only from git."
+description "A file (deleteme.rb) has accidentally been added to your staging area, find out which file and remove it from the staging area.  *NOTE* Do not remove the file from the the file system, only from git."
 
 setup do
   repo.init


### PR DESCRIPTION
The current wording of the rm_cached level (level 10) states that the player should not "remove the filesystem."  While true, this is not what the question is asking, rather, it wants the player to not remove the file _from_ the file system.
