### PR TITLE
Allow for `return' in solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,10 @@ setup do
 end
 
 solution do
-  solved = true
+  return false unless repo.status.files.keys.include?("README")
+  return false if repo.status.files["README"].untracked
 
-  solved = false unless repo.status.files.keys.include?("README")
-  solved = false if repo.status.files["README"].untracked
-
-  solved
+  true
 end
 
 hint do
@@ -80,16 +78,6 @@ You can also include multiple hints like this:
 hints [
   "You can type `git` in your shell to get a list of available git commands",
   "Check the man for `git add`"]
-```
-
- **note** Because `solution` is a Proc, you cannot prematurely return out of it and as a result, must put an explicit return on the last line of the solution block.
-
-```ruby
-solution do
-  solved = false
-  solved = true if repo.valid?
-  solved
-end
 ```
 
  By default, `setup` will remove all files from the game folder.  You do not need to include a setup method if you don't want an initial git repository (if you are testing `git init` or only checking an answer.)

--- a/lib/githug/level.rb
+++ b/lib/githug/level.rb
@@ -55,7 +55,8 @@ module Githug
     end
 
     def solution(&block)
-      @solution = block
+      singleton = class << self; self end
+      singleton.send :define_method, :_solution, &block
     end
 
     def setup(&block)
@@ -89,7 +90,7 @@ module Githug
     end
 
     def solve
-      @solution.call
+      _solution
     rescue
       false
     end


### PR DESCRIPTION
My friend sent me a link to this repo as an example of a neat learning tool for git. Nice work!

I noticed the explicit instructions in the README to avoid `return` statements in the levels solution DSL and thought it might be nice to support them instead.
