### PR TITLE
fix integration tests failing when `git config --global push.default` == simple

### DIFF
--- a/levels/push.rb
+++ b/levels/push.rb
@@ -42,6 +42,7 @@ setup do
   Dir.chdir cwd
   `git remote add origin #{tmpdir}/.git`
   `git fetch origin`
+  `git branch -u origin/master master`
 end
 
 solution do


### PR DESCRIPTION
I recommend this one
This should still work once git hits 2.0, and allows people to finish the level with a simple git push (like I think was intended)
