### PR TITLE
fix integration tests failing when `git config --global push.default` == simple

### DIFF
--- a/levels/push.rb
+++ b/levels/push.rb
@@ -42,6 +42,9 @@ setup do
   Dir.chdir cwd
   `git remote add origin #{tmpdir}/.git`
   `git fetch origin`
+
+  # config so push selects upstream correctly
+  `git config push.default matching`
 end
 
 solution do


### PR DESCRIPTION
This was the first fix that occurred to me, because it's basically just a local reverse of my global config when running the test. I don't think it really solves the underlying issue though.
