### PR TITLE
Correct order of commits in "reorder" solution

### DIFF
--- a/levels/reorder.rb
+++ b/levels/reorder.rb
@@ -22,10 +22,7 @@ setup do
 end
 
 solution do
-  return false unless repo.commits[2].message == "First commit"
-  return false unless repo.commits[1].message == "Second commit"
-  return false unless repo.commits[0].message == "Third commit"
-  true
+    `git log --format="%s"`.split.join("").match /Third.*Second.*First.*Initial/
 end
 
 hint do


### PR DESCRIPTION
The solution incorrectly expects "Third commit" to be the root commit,
"Second commit" to be the second commit, and so on.

These changes correct the order. The solution now expects that "Initial
Setup" is the root commit, that "First commit" is the second commit, and
so on.
