### PR TITLE
Updated solution to check commits in correct order

### DIFF
--- a/levels/revert.rb
+++ b/levels/revert.rb
@@ -22,8 +22,8 @@ solution do
   valid = false
   valid = true if repo.commits.length > 3 &&
     repo.commits[3].message == "First commit" &&
-    repo.commits[2].message == "Second commit" &&
-    repo.commits[1].message == "Bad commit" &&
+    repo.commits[2].message == "Bad commit" &&
+    repo.commits[1].message == "Second commit" &&
     repo.commits[0].message.split("\n").first == "Revert \"Bad commit\""
   valid
 end


### PR DESCRIPTION
The solution for this level checked for the commits in the wrong order as they were added in the setup, making the level impossible without a rebase to fix the issue.
