### PR TITLE
Update line number in diff.rb

### DIFF
--- a/levels/diff.rb
+++ b/levels/diff.rb
@@ -7,7 +7,7 @@ end
 
 solution do
   line = request "What is the number of the line which has changed?"
-  return false unless line == "26"
+  return false unless line == "23"
   true
 end
 


### PR DESCRIPTION
Looking at the output from git diff on this level, it seems the correct line number is 23…

``` diff
diff --git a/app.rb b/app.rb
index 4f703ca..3bfa839 100644
--- a/app.rb
+++ b/app.rb
@@ -23,7 +23,7 @@ get '/yet_another' do
   erb :success
 end
 get '/another_page' do
-  @message = get_response('data.json')
+  @message = get_response('server.json')
   erb :another
 end
```
