### PR TITLE
Corrected entirely wrong commit order for lvl 51 solution check.

### DIFF
--- a/levels/revert.rb
+++ b/levels/revert.rb
@@ -19,13 +19,11 @@ setup do
 end
 
 solution do
-  valid = false
-  valid = true if repo.commits.length > 3 &&
-    repo.commits[3].message == "First commit" &&
-    repo.commits[2].message == "Second commit" &&
-    repo.commits[1].message == "Bad commit" &&
+  repo.commits.length > 3 &&
+    repo.commits[3].message == "Second commit" &&
+    repo.commits[2].message == "Bad commit" &&
+    repo.commits[1].message == "First commit" &&
     repo.commits[0].message.split("\n").first == "Revert \"Bad commit\""
-  valid
 end
 
 hint do


### PR DESCRIPTION
Required incorrect order of commits for a completion via simple execution of revert. Level 51 CANNOT be completed in any obvious way without this fix.