### PR TITLE
fix squash with some tips.

### DIFF
--- a/levels/squash.rb
+++ b/levels/squash.rb
@@ -11,13 +11,13 @@ setup do
   repo.commit_all("Adding README")
   File.open("README", 'w') { |f| f.write("hey there") }
   repo.add("README")
-  repo.commit_all("Updating README")
+  repo.commit_all("Updating README (squash this commit into Adding README)")
   File.open("README", 'a') { |f| f.write("\nAdding some more text") }
   repo.add("README")
-  repo.commit_all("Updating README")
+  repo.commit_all("Updating README (squash this commit into Adding README)")
   File.open("README", 'a') { |f| f.write("\neven more text") }
   repo.add("README")
-  repo.commit_all("Updating README")
+  repo.commit_all("Updating README (squash this commit into Adding README)")
 end
 
 solution do


### PR DESCRIPTION
First of all, githug is a great game.

For level squash, I got following message
```bash
kltao-mac:git_hug kltao$ git log
commit 3a3db5a1e53dd81f85925135d6bb75ba6f8f5ac6
Author: legendtkl <taokelu@gmail.com>
Date:   Thu Dec 31 09:11:20 2015 +0800

    Updating README

commit 1ed37b524cd77dc1dbf6068e981be346c577422e
Author: legendtkl <taokelu@gmail.com>
Date:   Thu Dec 31 09:11:20 2015 +0800

    Updating README

commit a9ed7bc80ff305c2749fcf6330a970dac1854a6d
Author: legendtkl <taokelu@gmail.com>
Date:   Thu Dec 31 09:11:20 2015 +0800

    Updating README

commit 8886d84a6ffecf30c3ec00e879f816bcfb66b597
Author: legendtkl <taokelu@gmail.com>
Date:   Thu Dec 31 09:11:20 2015 +0800

    Adding README

commit 83cb5d3da65c245a7912bf134e775fff25cc8550
Author: legendtkl <taokelu@gmail.com>
Date:   Thu Dec 31 09:11:20 2015 +0800

    Initial Commit
```

Actually, there are three kinds of commit message, so I squash the three "Updating README", that means, end with leaving three commits (Initial Commit, Adding README, Updating README). Then I got failed.

So my point is that the answer with 3 commits seems to be a more reasonable and understandable answer. What are you thinking of it ?