### PR TITLE
Update "githug reset" function

### DIFF
--- a/lib/githug/cli.rb
+++ b/lib/githug/cli.rb
@@ -66,6 +66,7 @@ module Githug
     no_tasks do
 
       def load_level(path = nil)
+        path = Level.list[path.to_i - 1] if path.to_i.to_s == path and 0 < path.to_i and path.to_i <= Level.list.size
         return load_level_from_profile unless path
         return load_level_from_name(path) if Level.list.include?(path)
         Level.load_from_file(path)

--- a/lib/githug/cli.rb
+++ b/lib/githug/cli.rb
@@ -66,10 +66,15 @@ module Githug
     no_tasks do
 
       def load_level(path = nil)
-        path = Level.list[path.to_i - 1] if path.to_i.to_s == path and 0 < path.to_i and path.to_i <= Level.list.size
         return load_level_from_profile unless path
+        return load_level_from_number(path.to_i) if path.to_i.to_s == path
         return load_level_from_name(path) if Level.list.include?(path)
         Level.load_from_file(path)
+      end
+
+      def load_level_from_number(number)
+        level_name = number >= 1 ? Level.list[number - 1] : nil
+        return load_level_from_name(level_name)
       end
 
       def load_level_from_name(name)

--- a/lib/githug/cli.rb
+++ b/lib/githug/cli.rb
@@ -38,7 +38,7 @@ module Githug
       LEVEL parameter which will reset the game to a specific level. For
       example:
 
-      > $ githug reset merge_squash
+      > $ githug reset merge_squash   # or $ githug reset 45
 
       Will reset githug to level '#45: merge_squash'
     LONGDESC

--- a/spec/githug/cli_spec.rb
+++ b/spec/githug/cli_spec.rb
@@ -98,20 +98,24 @@ describe Githug::CLI do
         subject.reset("add")
       end
 
+      it "resets the level with a level number" do
+        level.should_receive(:setup_level)
+        level.should_receive(:full_description)
+        profile = mock
+        Githug::Profile.stub(:load).and_return(profile)
+        profile.should_receive(:set_level).with("45")
+        Githug::Level.should_receive(:load).with("45").and_return(level)
+        Githug::UI.should_receive(:word_box).with("Githug")
+        Githug::UI.should_receive(:puts).with("resetting level")
+        subject.reset("45")
+      end
+
       it "resets the level with a path" do
         level.should_receive(:setup_level)
         level.should_receive(:full_description)
         Githug::UI.should_receive(:word_box).with("Githug")
         Githug::UI.should_receive(:puts).with("resetting level")
         subject.reset("/foo/bar/level.rb")
-      end
-
-      it "resets the level with a number" do
-        level.should_receive(:setup_level)
-        level.should_receive(:full_description)
-        Githug::UI.should_receive(:word_box).with("Githug")
-        Githug::UI.should_receive(:puts).with("resetting level")
-        subject.reset("45")
       end
     end
 

--- a/spec/githug/cli_spec.rb
+++ b/spec/githug/cli_spec.rb
@@ -103,8 +103,8 @@ describe Githug::CLI do
         level.should_receive(:full_description)
         profile = mock
         Githug::Profile.stub(:load).and_return(profile)
-        profile.should_receive(:set_level).with("45")
-        Githug::Level.should_receive(:load).with("45").and_return(level)
+        profile.should_receive(:set_level).with("squash")
+        Githug::Level.should_receive(:load).with("squash").and_return(level)
         Githug::UI.should_receive(:word_box).with("Githug")
         Githug::UI.should_receive(:puts).with("resetting level")
         subject.reset("45")

--- a/spec/githug/cli_spec.rb
+++ b/spec/githug/cli_spec.rb
@@ -105,6 +105,14 @@ describe Githug::CLI do
         Githug::UI.should_receive(:puts).with("resetting level")
         subject.reset("/foo/bar/level.rb")
       end
+
+      it "resets the level with a number" do
+        level.should_receive(:setup_level)
+        level.should_receive(:full_description)
+        Githug::UI.should_receive(:word_box).with("Githug")
+        Githug::UI.should_receive(:puts).with("resetting level")
+        subject.reset("45")
+      end
     end
 
   end


### PR DESCRIPTION
Now `githug reset` only accept level name, such as `githug reset init` means change to the first level.

But I just want to make it accept numbers, such as `githug reset 1` to jump to the 1st level. I think it would be more convenient. That's why I made this pull request.

If you think this is good please accept this pull request. Thanks.