### PR TITLE
chore(gemspec): specify required rake version

### DIFF
--- a/githug.gemspec
+++ b/githug.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "grit", "~>2.3.0"
   s.add_dependency "thor", "~>0.14.6"
-  s.add_dependency "rake"
+  s.add_dependency "rake", "<11"
   # s.add_runtime_dependency "rest-client"
 end


### PR DESCRIPTION
rake v11 drops support for ruby version < 1.9.3

This PR fixes Travis builds on ruby 1.8.7 and 1.9.2 by explicitly specifying required rake version.

Drop a PR here in case it helps.