### PR TITLE
Fix rename_commit level solution

### DIFF
--- a/levels/rename_commit.rb
+++ b/levels/rename_commit.rb
@@ -17,7 +17,7 @@ setup do
 end
 
 solution do
-  repo.commits[1].message == "First commit"
+  repo.commits.first.message == "First commit"
 end
 
 hint do


### PR DESCRIPTION
I was unable to complete this level because `repo.commits[1]` was not the correct commit to be checking the message of.

When setting up the level "First coommit" does exist at `repo.commits[1]` but after renaming it via rebase it was always the first commit in the list (`repo.commits.first`).

It looks like the solution for this level used to work in a similar way - you can see where it was changed from using `.first` to using `[1]` here: https://github.com/Gazler/githug/commit/7dcc3ab8640a2958b892515d19113e5e5ff05bed

This pull request fixes #255 