### PR TITLE
Clarify that reset task can be used to select a specific level

### DIFF
--- a/lib/githug/cli.rb
+++ b/lib/githug/cli.rb
@@ -32,7 +32,7 @@ module Githug
       end
     end
 
-    desc :reset, "Reset the current level"
+    desc :reset, "Reset the current level or select specific level"
     long_desc <<-LONGDESC
       `githug reset` will reset the current level. You can optionally specify a
       LEVEL parameter which will reset the game to a specific level. For


### PR DESCRIPTION
I always forget that `githug reset` can be used to choose a specific level, not simply to reset the current level. This change to the short description that appears in `githug help` would help me remember!