### PR TITLE
Fix git help command in hint

### DIFF
--- a/levels/include.rb
+++ b/levels/include.rb
@@ -17,5 +17,5 @@ solution do
 end
 
 hint do
-  puts "Using `git gitignore --help`, read about the optional prefix to negate a pattern."
+  puts "Using `git help gitignore`, read about the optional prefix to negate a pattern."
 end


### PR DESCRIPTION
The hint says to use `git gitignore --help`, but that doesn't work:

```
> git gitignore --help
> git: 'gitignore' is not a git command. See 'git --help'.
```

Instead, the command that does work is `git help gitignore`.