### PR TITLE
Add CLI option to set Git default editor as VS Code instead of Vim.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,13 @@ Type `y` (yes) to continue, `n` (no) to cancel and quit Githug.
 
 ### Commands
 
-Githug has 4 game commands:
+Githug has 5 game commands:
 
  * play - The default command, checks your solution for the current level
  * hint - Gives you a hint (if available) for the current level
  * reset - Reset the current level or reset the level to a given name or path
  * levels - List all the levels
+ * vscode - Can't exit Vim? Switch your default Git editor to VS Code
 
 ## Change Log
 

--- a/lib/githug/cli.rb
+++ b/lib/githug/cli.rb
@@ -71,6 +71,23 @@ module Githug
       end
     end
 
+    desc :vscode, "Change your default Git editor to VS Code"
+
+    def vscode
+      UI.puts("Checking to see if you have VS Code installed...")
+      if system("code --help >/dev/null 2>&1")
+        UI.success("You have VS Code installed!")
+        UI.puts("Changing your Git config to use VS Code...")
+        if system("git config --global core.editor 'code --wait'")
+          UI.success("VS Code is now your default Git editor!")
+        else
+          UI.error("VS Code is installed, however an error occurred trying to edit your Git config.")
+        end
+      else
+        UI.error("VS Code may be uninstalled. If you are on Mac OSX, open VS Code, press SHIFT + CMD + P and select 'Shell Command: Install 'Code' command in path' from the Command Palette and try again.")
+      end
+    end
+
     no_tasks do
 
       def load_level(path = nil)


### PR DESCRIPTION
Added the 'githug vscode' CLI option to help newbies using githug to learn git, but who are getting overwhelmed with also having to deal with... exiting Vim!

Fully understand if this gets rejected as it's not a significant feature, but it's late, i'm tired and I want to finish Level 56 (making a pull request on GitHub to the repository) before going to bed.

Good night!