### PR TITLE
Fixing line number to be verified in git diff check

### DIFF
--- a/levels/diff.rb
+++ b/levels/diff.rb
@@ -7,7 +7,7 @@ end
 
 solution do
   line = request "What is the number of the line which has changed?"
-  return false unless line == "26"
+  return false unless line == "23"
   true
 end
 


### PR DESCRIPTION
Currently it is checking for line 26 whereas git diff shows line 23 to be the modified line.