### PR TITLE
Fix rename_commit level solution

### DIFF
--- a/levels/rename_commit.rb
+++ b/levels/rename_commit.rb
@@ -17,7 +17,7 @@ setup do
 end
 
 solution do
-  repo.commits[1].message == "First commit"
+  repo.commits.first.parents[0].message == "First commit"
 end
 
 hint do


### PR DESCRIPTION
Fixes #258 

The problem is that `repo.commits` as an array is not necessarily ordered by parent commits. So `repo.commits[1]` could virtually be any commit in the repo.
As an exemple, here is what I get:
```ruby
  puts repo.commits[0].message
  puts repo.commits[1].message
  puts repo.commits[2].message
```
-> BEFORE `rebase -i`:
```
Initial commit
First coommit
Second commit
```
-> AFTER `rebase -i` and renaming the middle commit:
```
Second commit
Initial commit
First commit
```

This fix ensures that we look at the parent of the latest commit.