### PR TITLE
fix(gemspec): update and amend installation

### DIFF
--- a/githug.gemspec
+++ b/githug.gemspec
@@ -8,10 +8,9 @@ Gem::Specification.new do |s|
   s.authors     = ["Gary Rennie"]
   s.email       = ["webmaster@gazler.com"]
   s.homepage    = "https://github.com/Gazler/githug"
+  s.license     = "MIT"
   s.summary     = %q{An interactive way to learn git.}
-  s.description = %q{An interactive way to learn git.}
-
-  s.rubyforge_project = "githug"
+  s.description = %q{A Ruby implemented game for the the CLI to learn core concepts of git.}
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
@@ -21,7 +20,7 @@ Gem::Specification.new do |s|
   # specify any dependencies here; for example:
   s.add_development_dependency "rspec", "~>2.8.0"
 
-  s.add_dependency "grit", "~>2.3.0"
-  s.add_dependency "thor", "~>0.14.6"
-  s.add_dependency "rake", "<11"
+  s.add_dependency "grit", "~>2.5.0"
+  s.add_dependency "thor", "~>1.3.1"
+  s.add_dependency "rake", "~>13.1.0"
 end


### PR DESCRIPTION
The previously used definitions did not yield an executable in Ubuntu 22.04 LTS.  An explicit note to the license was added.