### PR TITLE
fix(include.rb): correct hint to man page

### DIFF
--- a/levels/include.rb
+++ b/levels/include.rb
@@ -17,5 +17,5 @@ solution do
 end
 
 hint do
-  puts "Using `git help gitignore`, read about the optional prefix to negate a pattern."
+  puts "Using `git help ignore`, read about the optional prefix to negate a pattern."
 end


### PR DESCRIPTION
In git (version 2.43.0), the command to access the corresponding man page differs to the one the hint so far indicated.